### PR TITLE
Runtime Module Management

### DIFF
--- a/Aurie/source/AurieMain.cpp
+++ b/Aurie/source/AurieMain.cpp
@@ -78,11 +78,7 @@ void ArProcessAttach(HINSTANCE Instance)
 		Internal::MdpCreateModule(
 			process_name,
 			Instance,
-			nullptr,
-			nullptr,
-			nullptr,
-			nullptr,
-			nullptr,
+			false,
 			0,
 			initial_module
 		)
@@ -124,6 +120,7 @@ void ArProcessAttach(HINSTANCE Instance)
 	Internal::MdpMapFolder(
 		folder_path,
 		true,
+		false,
 		nullptr
 	);
 
@@ -167,7 +164,7 @@ void ArProcessAttach(HINSTANCE Instance)
 		ElWaitForCurrentProcessWindow();
 
 	WaitForInputIdle(GetCurrentProcess(), INFINITE);
-		
+
 	// Call ModuleEntry on all loaded plugins
 	for (auto& entry : Internal::g_LdrModuleList)
 	{

--- a/Aurie/source/framework/Module Manager/module.cpp
+++ b/Aurie/source/framework/Module Manager/module.cpp
@@ -6,11 +6,7 @@ namespace Aurie
 	AurieStatus Internal::MdpCreateModule(
 		IN const fs::path& ImagePath, 
 		IN HMODULE ImageModule,
-		IN AurieEntry ModuleInitialize, 
-		IN AurieEntry ModulePreinitialize,
-		IN AurieEntry ModuleUnload,
-		IN AurieLoaderEntry FrameworkInitialize,
-		IN AurieModuleCallback ModuleOperationCallback,
+		IN bool ProcessExports,
 		IN uint8_t BitFlags,
 		OUT AurieModule& Module
 	)
@@ -21,11 +17,20 @@ namespace Aurie
 		// Populate known fields first
 		temp_module.Flags.Bitfield = BitFlags;
 		temp_module.ImagePath = ImagePath;
-		temp_module.ModuleInitialize = ModuleInitialize;
-		temp_module.ModulePreinitialize = ModulePreinitialize;
-		temp_module.FrameworkInitialize = FrameworkInitialize;
-		temp_module.ModuleOperationCallback = ModuleOperationCallback;
-		temp_module.ModuleUnload = ModuleUnload;
+
+		if (ProcessExports)
+		{
+			last_status = MdpProcessImageExports(
+				ImagePath,
+				ImageModule,
+				&temp_module
+			);
+
+			if (!AurieSuccess(last_status))
+			{
+				return last_status;
+			}
+		}
 
 		last_status = MdpQueryModuleInformation(
 			ImageModule,
@@ -281,6 +286,50 @@ namespace Aurie
 		return AURIE_SUCCESS;
 	}
 
+	AurieStatus Internal::MdpProcessImageExports(
+		IN const fs::path& ImagePath, 
+		IN HMODULE ImageBaseAddress, 
+		IN OUT AurieModule* ModuleImage
+	)
+	{
+		// Find all the required functions
+		uintptr_t framework_init_offset = PpFindFileExportByName(ImagePath, "__AurieFrameworkInit");
+		uintptr_t module_init_offset = PpFindFileExportByName(ImagePath, "ModuleInitialize");
+
+		uintptr_t module_callback_offset = PpFindFileExportByName(ImagePath, "ModuleOperationCallback");
+		uintptr_t module_preload_offset = PpFindFileExportByName(ImagePath, "ModulePreinitialize");
+		uintptr_t module_unload_offset = PpFindFileExportByName(ImagePath, "ModuleUnload");
+
+		// Cast the problems away
+		char* image_base = reinterpret_cast<char*>(ImageBaseAddress);
+
+		AurieEntry module_init = reinterpret_cast<AurieEntry>(image_base + module_init_offset);
+		AurieEntry module_preload = reinterpret_cast<AurieEntry>(image_base + module_preload_offset);
+		AurieEntry module_unload = reinterpret_cast<AurieEntry>(image_base + module_unload_offset);
+		AurieLoaderEntry framework_init = reinterpret_cast<AurieLoaderEntry>(image_base + framework_init_offset);
+		AurieModuleCallback module_callback = reinterpret_cast<AurieModuleCallback>(image_base + module_callback_offset);
+
+		// If the offsets are zero, the function wasn't found, which means we shouldn't populate the field.
+		if (module_init_offset)
+			ModuleImage->ModuleInitialize = module_init;
+
+		if (module_preload_offset)
+			ModuleImage->ModulePreinitialize = module_preload;
+
+		if (framework_init_offset)
+			ModuleImage->FrameworkInitialize = framework_init;
+
+		if (module_callback_offset)
+			ModuleImage->ModuleOperationCallback = module_callback;
+
+		if (module_unload_offset)
+			ModuleImage->ModuleUnload = module_unload;
+
+		// We always need __AurieFrameworkInit to exist.
+		// We also need either a ModuleInitialize or a ModulePreinitialize function.
+		return ((module_init_offset || module_preload_offset) && framework_init_offset) ? AURIE_SUCCESS : AURIE_FILE_PART_NOT_FOUND;
+	}
+
 	// The ignoring of return values here is on purpose, we just have to power through
 	// and unload / free what we can.
 	AurieStatus Internal::MdpUnmapImage(
@@ -376,6 +425,7 @@ namespace Aurie
 	void Internal::MdpMapFolder(
 		IN const fs::path& Folder, 
 		IN bool Recursive,
+		IN bool IsRuntimeLoad,
 		OPTIONAL OUT size_t* NumberOfMappedModules
 	)
 	{
@@ -413,7 +463,7 @@ namespace Aurie
 		{
 			AurieModule* loaded_module = nullptr;
 
-			if (AurieSuccess(MdMapImage(module, loaded_module)))
+			if (AurieSuccess(MdMapImageEx(module, IsRuntimeLoad, loaded_module)))
 				loaded_count++;
 		}
 
@@ -426,6 +476,19 @@ namespace Aurie
 		OUT AurieModule*& Module
 	)
 	{
+		return MdMapImageEx(
+			ImagePath,
+			true,
+			Module
+		);
+	}
+
+	AurieStatus MdMapImageEx(
+		IN const fs::path& ImagePath,
+		IN bool IsRuntimeLoad,
+		OUT AurieModule*& Module
+	)
+	{
 		AurieStatus last_status = AURIE_SUCCESS;
 		HMODULE image_base = nullptr;
 
@@ -435,62 +498,49 @@ namespace Aurie
 		if (!AurieSuccess(last_status))
 			return last_status;
 
-		// Find all the required functions
-		uintptr_t framework_init_offset = PpFindFileExportByName(ImagePath, "__AurieFrameworkInit");
-		uintptr_t module_init_offset = PpFindFileExportByName(ImagePath, "ModuleInitialize");
-
-		uintptr_t module_callback_offset = PpFindFileExportByName(ImagePath, "ModuleOperationCallback");
-		uintptr_t module_preload_offset = PpFindFileExportByName(ImagePath, "ModulePreinitialize");
-		uintptr_t module_unload_offset = PpFindFileExportByName(ImagePath, "ModuleUnload");
-
-		AurieEntry module_init = reinterpret_cast<AurieEntry>((char*)image_base + module_init_offset);
-		AurieEntry module_preload = reinterpret_cast<AurieEntry>((char*)image_base + module_preload_offset);
-		AurieEntry module_unload = reinterpret_cast<AurieEntry>((char*)image_base + module_unload_offset);
-		AurieLoaderEntry fwk_init = reinterpret_cast<AurieLoaderEntry>((char*)image_base + framework_init_offset);
-		AurieModuleCallback module_callback = reinterpret_cast<AurieModuleCallback>((char*)image_base + module_callback_offset);
-
-		// Verify image integrity
-		last_status = Internal::MmpVerifyCallback(image_base, module_init);
-		if (!AurieSuccess(last_status))
-			return last_status;
-
-		last_status = Internal::MmpVerifyCallback(image_base, fwk_init);
-		if (!AurieSuccess(last_status))
-			return last_status;
-
-		// MdiMapImage checks for __aurie_fwk_init and ModuleInitialize, but doesn't check ModulePreinitialize since it's optional
-		// If the offsets are null, the thing wasn't found, and we shouldn't try to call it
-		if (!module_preload_offset)
-			module_preload = nullptr;
-
-		if (!module_unload_offset)
-			module_unload = nullptr;
-
-		if (!module_callback_offset)
-			module_callback = nullptr;
-
 		// Create the module object
 		AurieModule module_object = {};
 		last_status = Internal::MdpCreateModule(
 			ImagePath,
 			image_base,
-			module_init,
-			module_preload,
-			module_unload,
-			fwk_init,
-			module_callback,
+			true,
 			0,
 			module_object
 		);
 
-		// TODO: Invoke module load callbacks
-
+		// Verify image integrity
+		last_status = Internal::MmpVerifyCallback(module_object.ImageBase.Module, module_object.FrameworkInitialize);
 		if (!AurieSuccess(last_status))
 			return last_status;
+
+		Module->Flags.IsRuntimeLoaded = IsRuntimeLoad;
+
+		if (IsRuntimeLoad)
+		{
+			// We don't dispatch a ModulePreinitialize for runtime-loaded modules,
+			// since their ModulePreinitialize function wouldn't run before
+			// the process started executing code (defeating the purpose of ModulePreinitialize)
+			last_status = Internal::MdpDispatchEntry(
+				Module,
+				Module->ModuleInitialize
+			);
+
+			if (!AurieSuccess(last_status))
+				return last_status;
+
+			Module->Flags.IsInitialized = true;
+		}
 
 		// Add it to our list of modules
 		Module = Internal::MdpAddModuleToList(std::move(module_object));
 		return AURIE_SUCCESS;
+	}
+
+	bool MdIsImageRuntimeLoaded(
+		IN AurieModule* Module
+	)
+	{
+		return Module->Flags.IsRuntimeLoaded;
 	}
 
 	bool MdIsImageInitialized(
@@ -511,6 +561,7 @@ namespace Aurie
 		Internal::MdpMapFolder(
 			FolderPath,
 			Recursive,
+			true,
 			nullptr
 		);
 

--- a/Aurie/source/framework/Module Manager/module.hpp
+++ b/Aurie/source/framework/Module Manager/module.hpp
@@ -13,12 +13,22 @@ namespace Aurie
 		OUT AurieModule*& Module
 	);
 
+	AurieStatus MdMapImageEx(
+		IN const fs::path& ImagePath,
+		IN bool IsRuntimeLoad,
+		OUT AurieModule*& Module
+	);
+
 	EXPORTED bool MdIsImagePreinitialized(
 		IN AurieModule* Module
 	);
 
 	// Checks whether an image is initialized or not
 	EXPORTED bool MdIsImageInitialized(
+		IN AurieModule* Module
+	);
+
+	EXPORTED bool MdIsImageRuntimeLoaded(
 		IN AurieModule* Module
 	);
 
@@ -44,11 +54,7 @@ namespace Aurie
 		AurieStatus MdpCreateModule(
 			IN const fs::path& ImagePath,
 			IN HMODULE ImageModule,
-			IN AurieEntry ModuleInitialize,
-			IN AurieEntry ModulePreinitialize,
-			IN AurieEntry ModuleUnload,
-			IN AurieLoaderEntry FrameworkInitialize,
-			IN AurieModuleCallback ModuleOperationCallback,
+			IN bool ProcessExports,
 			IN uint8_t BitFlags,
 			OUT AurieModule& Module
 		);
@@ -112,6 +118,12 @@ namespace Aurie
 			OUT AurieModule*& Module
 		);
 
+		AurieStatus MdpProcessImageExports(
+			IN const fs::path& ImagePath,
+			IN HMODULE ImageBaseAddress,
+			OUT AurieModule* ModuleImage
+		);
+
 		AurieStatus MdpUnmapImage(
 			IN AurieModule* Module,
 			IN bool RemoveFromList,
@@ -126,6 +138,7 @@ namespace Aurie
 		void MdpMapFolder(
 			IN const fs::path& Folder,
 			IN bool Recursive,
+			IN bool IsRuntimeLoad,
 			OPTIONAL OUT size_t* NumberOfMappedModules
 		);
 

--- a/Aurie/source/framework/framework.hpp
+++ b/Aurie/source/framework/framework.hpp
@@ -70,7 +70,8 @@ namespace Aurie
 				// If this bit is set, the module's Preload function has been called.
 				// This call to Preload happens before the call to Initialize.
 				// 
-				// If the Aurie Framework is injected into a running process, this function does not run.
+				// If the Aurie Framework is injected into a running process, this function is called
+				// right before the call to Initialize.
 				// Otherwise, this function is guaranteed to run before the main process's entrypoint.
 				bool IsPreloaded : 1;
 

--- a/Aurie/source/framework/shared.hpp
+++ b/Aurie/source/framework/shared.hpp
@@ -48,7 +48,7 @@
 #endif // AURIE_FWK_MINOR
 
 #ifndef AURIE_FWK_PATCH
-#define AURIE_FWK_PATCH 2
+#define AURIE_FWK_PATCH 3
 #endif // AURIE_FWK_PATCH
 
 
@@ -424,6 +424,14 @@ namespace Aurie
 	{
 		return AURIE_API_CALL(MdIsImageInitialized, Module);
 	}
+
+	inline bool MdIsImageRuntimeLoaded(
+		IN AurieModule* Module
+	)
+	{
+		return AURIE_API_CALL(MdIsImageRuntimeLoaded, Module);
+	}
+
 
 	inline AurieStatus MdMapFolder(
 		IN const fs::path& FolderPath,

--- a/TestModule/source/Aurie/shared.hpp
+++ b/TestModule/source/Aurie/shared.hpp
@@ -48,7 +48,7 @@
 #endif // AURIE_FWK_MINOR
 
 #ifndef AURIE_FWK_PATCH
-#define AURIE_FWK_PATCH 2
+#define AURIE_FWK_PATCH 3
 #endif // AURIE_FWK_PATCH
 
 
@@ -424,6 +424,14 @@ namespace Aurie
 	{
 		return AURIE_API_CALL(MdIsImageInitialized, Module);
 	}
+
+	inline bool MdIsImageRuntimeLoaded(
+		IN AurieModule* Module
+	)
+	{
+		return AURIE_API_CALL(MdIsImageRuntimeLoaded, Module);
+	}
+
 
 	inline AurieStatus MdMapFolder(
 		IN const fs::path& FolderPath,


### PR DESCRIPTION
- Enables module management at runtime
- MdMapImage no longer resolves exports, instead that's done by MdpProcessImageExports called from MdpCreateModule (if ProcessExports flag is set)
- Added MdIsImageRuntimeLoaded export
- Changed module to only require EITHER ModuleInitialize or ModulePreinitialize, not both.