### PR TITLE
Universal event system

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Native x64 modding framework supporting Windows 8.1 => Windows 11.
 
 Aurie Framework allows the following:
 - Runtime module loading / unloading
-- Module interoperability through interfaces
-- Hooks using SafetyHook
-- Leak-prone memory management
+- Module interoperability through interfaces and events
+- Safe executable hooking
+- Leak-proof memory management
 - Code execution before the executable's entrypoint is ran
 
 ## Getting help


### PR DESCRIPTION
Removes module operation callbacks in favor of a documented callback interface inspired by the Windows Executive Layer.